### PR TITLE
Rename ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install -r requirements.txt
 ### Environment variables
 add an .env file and set the authentication token, like here:
 ```
-AUTH_KEY="your_token"
+DEEPL_KEY="your_token"
 ```
 
 ### Other environment variables

--- a/transjson/__main__.py
+++ b/transjson/__main__.py
@@ -22,7 +22,7 @@ class Translate(threading.Thread):
 
 @click.command
 @click.argument("filename", type=click.Path(exists=True, dir_okay=False))
-@click.option("-k", "--key", envvar="AUTH_KEY")
+@click.option("-k", "--key", envvar="DEEPL_KEY")
 @click.option("-l", "--lang", multiple=True, default=["es"])
 @click.option("-d", "--directory", default=".", type=click.Path(file_okay=False))
 def transjson(filename, key, lang, directory):


### PR DESCRIPTION
Camiar el `AUTH_KEY` por `DEEPL_KEY` para no sobreescribir cualquier otra env del proyecto donde se utulice la herramienta